### PR TITLE
Fixed wrong url on Throttle method

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ configure timings in which events in your bloc's are processed.
 
 Available transformers:
 
-- [throttle](https://bloc-event-transformers.web.app/bloc_event_transformers/debounce.html)
+- [throttle](https://bloc-event-transformers.web.app/bloc_event_transformers/throttle.html)
 - [debounce](https://bloc-event-transformers.web.app/bloc_event_transformers/debounce.html)
 - [skip](https://bloc-event-transformers.web.app/bloc_event_transformers/skip.html)
 - [delay](https://bloc-event-transformers.web.app/bloc_event_transformers/delay.html)


### PR DESCRIPTION
In previous throttle documentation link was refering to debounce page instead of throttle